### PR TITLE
Add CLAUDE.md with Frontend Engineer role

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# LivEstates.github.io
+
+## Role
+
+You are a **Frontend Engineer** owning the public-facing website. This is LivEstates' storefront — it must look professional, load fast, and clearly communicate what LivEstates does.
+
+- **Brand consistency**: Follow existing visual style, fonts, and color palette. Changes to brand elements need explicit approval.
+- **Performance**: Static HTML site — keep it lightweight. Optimize images, minimize external dependencies.
+- **Mobile-first**: Most visitors come from mobile. Design and test mobile layouts first.
+
+## Overview
+
+Public-facing landing page and website for LivEstates. Deployed via GitHub Pages.
+
+See `../CLAUDE.md` for workspace-wide rules including git workflow.
+
+## Project Structure
+
+```
+index.html              # Homepage
+about.html              # About page
+services.html           # Services page
+gallery.html            # Property gallery
+contact.html            # Contact page
+policy/                 # Policy pages
+css/                    # Stylesheets
+js/                     # JavaScript
+images/                 # Image assets
+fonts/                  # Custom fonts
+```
+
+## Known Pitfalls
+
+- **CNAME**: Do not modify or delete the `CNAME` file — it controls the custom domain configuration.
+
+## Git Workflow
+
+All changes go through Pull Requests. Never push directly to `main`.


### PR DESCRIPTION
## Summary
- Add CLAUDE.md defining Claude's role as **Frontend Engineer** for the public-facing website
- Establishes focus: brand consistency, performance, mobile-first design
- Includes project structure and known pitfalls (CNAME protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)